### PR TITLE
refactor!: cleanup disposables

### DIFF
--- a/packages/create-disposables/src/create-disposables.ts
+++ b/packages/create-disposables/src/create-disposables.ts
@@ -3,19 +3,22 @@ export function createDisposables() {
 
   return {
     async dispose() {
-      const toDispose = new Set(Array.from(disposables).reverse());
+      const toDispose = Array.from(disposables).reverse();
       disposables.clear();
       for (const dispose of toDispose) {
         await dispose();
       }
     },
-    add<T extends { dispose(): unknown } | (() => unknown)>(disposable: T): T {
+    add(disposable: Disposable) {
       if (typeof disposable === 'function') {
         disposables.add(disposable);
       } else {
         disposables.add(() => disposable.dispose());
       }
-      return disposable;
     },
   };
 }
+
+export type DisposeFunction = () => unknown;
+export type Disposable = { dispose: DisposeFunction } | DisposeFunction;
+export type Disposables = ReturnType<typeof createDisposables>;


### PR DESCRIPTION
* Avoid create a set when not necessary
* No return on add
* Expose proper types to avoid `ReturnType<typeof createDisposables>` in consumers

Breaking Change requires major version. 