### PR TITLE
fix: mocha-play sleep, promise in waitForCall, getIntervalPerformance

### DIFF
--- a/packages/testing/src/measure-machine.ts
+++ b/packages/testing/src/measure-machine.ts
@@ -1,14 +1,36 @@
-import { sleep } from 'promise-assist';
+import { deferred } from 'promise-assist';
 
 export async function getIntervalPerformance() {
     performance.mark('intervalStart');
     let intervalCount = 0;
-    const interval = setInterval(() => intervalCount++, 5);
 
-    await sleep(209);
+    const count = 20,
+        size = 1000,
+        intervalTime = 5,
+        ideaTime = intervalTime * count;
+
+    const done = deferred();
+    const interval = setInterval(() => {
+        if (++intervalCount > count) {
+            done.resolve();
+        }
+    }, intervalTime);
+
+    const busyBoxes = [];
+    const bbResults: number[] = [];
+    for (let i = 0; i < count * intervalTime * 10; i++) {
+        busyBoxes[i] = setTimeout(() => {
+            const a = new Array(size).fill(0).map(() => Math.random());
+            bbResults.push(a.sort().reduce((sum, n) => sum + n, 0));
+        }, i);
+    }
+
+    await done.promise;
+    busyBoxes.forEach((b) => clearTimeout(b));
+
     clearInterval(interval);
     performance.mark('intervalEnd');
 
     const { duration } = performance.measure('interval', 'intervalStart', 'intervalEnd');
-    return duration / intervalCount / 5;
+    return duration / ideaTime;
 }

--- a/packages/testing/src/measure-machine.ts
+++ b/packages/testing/src/measure-machine.ts
@@ -1,17 +1,17 @@
 import { deferred } from 'promise-assist';
 
+export const intervalCount = 20,
+    busyBoxWorkSize = 1000,
+    intervalTime = 5,
+    ideaTime = intervalTime * intervalCount;
+
 export async function getIntervalPerformance() {
     performance.mark('intervalStart');
-    let intervalCount = 0;
-
-    const count = 20,
-        size = 1000,
-        intervalTime = 5,
-        ideaTime = intervalTime * count;
+    let count = 0;
 
     const done = deferred();
     const interval = setInterval(() => {
-        if (++intervalCount > count) {
+        if (++count >= intervalCount) {
             done.resolve();
         }
     }, intervalTime);
@@ -20,7 +20,7 @@ export async function getIntervalPerformance() {
     const bbResults: number[] = [];
     for (let i = 0; i < count * intervalTime * 10; i++) {
         busyBoxes[i] = setTimeout(() => {
-            const a = new Array(size).fill(0).map(() => Math.random());
+            const a = new Array(busyBoxWorkSize).fill(0).map(() => Math.random());
             bbResults.push(a.sort().reduce((sum, n) => sum + n, 0));
         }, i);
     }

--- a/packages/testing/src/steps/poll.ts
+++ b/packages/testing/src/steps/poll.ts
@@ -33,7 +33,7 @@ export function pollStep<T>(
         }
     };
 
-    predicate = predicate || ((v: Awaited<T>) => !!v);
+    predicate = predicate === undefined ? ((v: Awaited<T>) => !!v) : predicate;
     const _predicate = (
         typeof predicate === 'function' ? predicate : (v: Awaited<T>) => expect(v).to.eql(predicate)
     ) as Predicate<T>;

--- a/packages/testing/src/steps/poll.ts
+++ b/packages/testing/src/steps/poll.ts
@@ -33,7 +33,7 @@ export function pollStep<T>(
         }
     };
 
-    predicate = predicate === undefined ? ((v: Awaited<T>) => !!v) : predicate;
+    predicate = predicate === undefined ? (v: Awaited<T>) => !!v : predicate;
     const _predicate = (
         typeof predicate === 'function' ? predicate : (v: Awaited<T>) => expect(v).to.eql(predicate)
     ) as Predicate<T>;

--- a/packages/testing/src/steps/steps.ts
+++ b/packages/testing/src/steps/steps.ts
@@ -1,6 +1,6 @@
 import { isString } from '@wixc3/common';
 import { deferred } from 'promise-assist';
-import { getIntervalPerformance } from '../measure-machine';
+import { getIntervalPerformance, ideaTime } from '../measure-machine';
 import { pollStep, Predicate } from './poll';
 import { PromiseStep, promiseStep } from './promise';
 
@@ -14,13 +14,13 @@ export class Steps {
         step: {
             timeout: 1000,
             safetyMargin: 50,
-            adjustToMachinePower: true,
+            adjustToMachinePower: true
         },
         poll: {
             interval: 100,
             allowActionError: false,
-            allowPredicateError: true,
-        },
+            allowPredicateError: true
+        }
     };
     private stepCount = 1;
     private getStack() {
@@ -50,7 +50,7 @@ export class Steps {
     poll = <T>(action: () => T, predicate?: Predicate<T> | Awaited<T>) => {
         this.addTimeoutSafetyMargin();
         const {
-            poll: { interval, allowActionError, allowPredicateError },
+            poll: { interval, allowActionError, allowPredicateError }
         } = this.defaults;
 
         const step = pollStep(action, predicate, this.mochaCtx, Steps.timeDilation)
@@ -116,7 +116,8 @@ export class Steps {
     };
 }
 
-before(async () => {
+before('check time', async function () {
+    this.timeout(ideaTime * 30);
     Steps.timeDilation = await getIntervalPerformance();
     // eslint-disable-next-line no-console
     console.log(`Time dilation due to machine power: ${Steps.timeDilation}`);

--- a/packages/testing/src/steps/steps.ts
+++ b/packages/testing/src/steps/steps.ts
@@ -14,13 +14,13 @@ export class Steps {
         step: {
             timeout: 1000,
             safetyMargin: 50,
-            adjustToMachinePower: true
+            adjustToMachinePower: true,
         },
         poll: {
             interval: 100,
             allowActionError: false,
-            allowPredicateError: true
-        }
+            allowPredicateError: true,
+        },
     };
     private stepCount = 1;
     private getStack() {
@@ -50,7 +50,7 @@ export class Steps {
     poll = <T>(action: () => T, predicate?: Predicate<T> | Awaited<T>) => {
         this.addTimeoutSafetyMargin();
         const {
-            poll: { interval, allowActionError, allowPredicateError }
+            poll: { interval, allowActionError, allowPredicateError },
         } = this.defaults;
 
         const step = pollStep(action, predicate, this.mochaCtx, Steps.timeDilation)

--- a/packages/testing/src/test/poll-step.unit.ts
+++ b/packages/testing/src/test/poll-step.unit.ts
@@ -123,4 +123,25 @@ describe('withSteps', () => {
             });
         });
     });
+    it(
+        `doesn't poll after the step is done`,
+        withSteps(async ({ poll, mochaCtx, sleep }) => {
+            mochaCtx.timeout();
+            let count = 0;
+            await poll(() => ++count, 3).interval(1);
+            await sleep(50);
+            expect(count).to.equal(3);
+            await expect(
+                poll(
+                    () => ++count,
+                    () => false
+                )
+                    .interval(1)
+                    .timeout(1)
+            ).to.eventually.rejectedWith('Timed out');
+            const lastCount = count;
+            await sleep(50);
+            expect(count).to.equal(lastCount);
+        })
+    );
 });

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -24,7 +24,7 @@ describe('withSteps', () => {
                     )
                 ).to.eventually.rejectedWith('Timed out'),
                 expect(step.waitForCall({ m: () => 0 }, 'm')).to.eventually.rejectedWith('Timed out'),
-                expect(step.waitForStubCall(() => 0)).to.eventually.rejectedWith('Timed out'),
+                expect(step.waitForStubCall(() => 0)).to.eventually.rejectedWith('Timed out')
             ]);
             expect(step.mochaCtx.timeout()).to.be.approximately(
                 1_000 + Steps.timeDilation * (+4 * TIMEOUT + 4 * SAFETY_MARGIN),
@@ -40,16 +40,21 @@ describe('withSteps', () => {
             'times out with the description',
             withSteps(async (step) => {
                 await expect(
-                    step.withTimeout(sleep(LONG_TIME)).timeout(SHORT_TIME).description('test')
+                    step
+                        .withTimeout(sleep(LONG_TIME * Steps.timeDilation))
+                        .timeout(SHORT_TIME)
+                        .description('test')
                 ).to.eventually.rejectedWith('test');
             })
         );
         it(
             'fulfils the promise in the allotted time',
             withSteps(async (step) => {
-                expect(await step.withTimeout(sleep(SHORT_TIME).then(() => 'success')).timeout(LONG_TIME)).to.equal(
-                    'success'
-                );
+                expect(
+                    await step
+                        .withTimeout(sleep(SHORT_TIME * Steps.timeDilation).then(() => 'success'))
+                        .timeout(LONG_TIME)
+                ).to.equal('success');
             })
         );
     });
@@ -63,7 +68,7 @@ describe('withSteps', () => {
                 method(a: number, b: string) {
                     this.a = a;
                     this.b = b;
-                },
+                }
             };
         });
         it(
@@ -115,7 +120,7 @@ describe('withSteps', () => {
                     })
                 ).to.eql({
                     callArgs: ['success'],
-                    returned: 'action!',
+                    returned: 'action!'
                 });
             })
         );

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -15,7 +15,7 @@ describe('withSteps', () => {
             step.mochaCtx.timeout(1_000);
             step.defaults.step.safetyMargin = SAFETY_MARGIN;
             step.defaults.step.timeout = TIMEOUT;
-            await Promise.all([
+            await Promise.allSettled([
                 expect(step.withTimeout(new Promise(() => 0))).to.eventually.rejectedWith('Timed out'),
                 expect(
                     step.poll(

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -1,4 +1,3 @@
-import { sleep } from 'promise-assist';
 import { expect, use } from 'chai';
 import asPromised from 'chai-as-promised';
 import { Steps, withSteps } from '../steps';
@@ -38,22 +37,17 @@ describe('withSteps', () => {
         const SHORT_TIME = 1;
         it(
             'times out with the description',
-            withSteps(async (step) => {
+            withSteps(async ({ sleep, withTimeout }) => {
                 await expect(
-                    step
-                        .withTimeout(sleep(LONG_TIME * Steps.timeDilation))
-                        .timeout(SHORT_TIME)
-                        .description('test')
+                    withTimeout(sleep(LONG_TIME)).timeout(SHORT_TIME).description('test')
                 ).to.eventually.rejectedWith('test');
             })
         );
         it(
             'fulfils the promise in the allotted time',
-            withSteps(async (step) => {
+            withSteps(async ({ sleep, withTimeout }) => {
                 expect(
-                    await step
-                        .withTimeout(sleep(SHORT_TIME * Steps.timeDilation).then(() => 'success'))
-                        .timeout(LONG_TIME)
+                    await withTimeout(sleep(SHORT_TIME * Steps.timeDilation).then(() => 'success')).timeout(LONG_TIME)
                 ).to.equal('success');
             })
         );
@@ -111,9 +105,9 @@ describe('withSteps', () => {
     describe('waitForStubCall', () => {
         it(
             'resolves to {callArgs, returned}',
-            withSteps(async (steps) => {
+            withSteps(async ({ sleep, waitForStubCall }) => {
                 expect(
-                    await steps.waitForStubCall(async (stub) => {
+                    await waitForStubCall(async (stub) => {
                         await sleep(1);
                         stub('success');
                         return 'action!';
@@ -126,14 +120,12 @@ describe('withSteps', () => {
         );
         it(
             'times out when the stub is not called',
-            withSteps(async (steps) => {
+            withSteps(async ({ sleep, waitForStubCall }) => {
                 await expect(
-                    steps
-                        .waitForStubCall(async (stub) => {
-                            await sleep(100);
-                            stub('success');
-                        })
-                        .timeout(10)
+                    waitForStubCall(async (stub) => {
+                        await sleep(100);
+                        stub('success');
+                    }).timeout(10)
                 ).to.eventually.rejectedWith('Timed out');
             })
         );

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -15,7 +15,7 @@ describe('withSteps', () => {
             step.mochaCtx.timeout(1_000);
             step.defaults.step.safetyMargin = SAFETY_MARGIN;
             step.defaults.step.timeout = TIMEOUT;
-            await Promise.allSettled([
+            await Promise.all([
                 expect(step.withTimeout(new Promise(() => 0))).to.eventually.rejectedWith('Timed out'),
                 expect(
                     step.poll(

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -23,7 +23,7 @@ describe('withSteps', () => {
                     )
                 ).to.eventually.rejectedWith('Timed out'),
                 expect(step.waitForCall({ m: () => 0 }, 'm')).to.eventually.rejectedWith('Timed out'),
-                expect(step.waitForStubCall(() => 0)).to.eventually.rejectedWith('Timed out')
+                expect(step.waitForStubCall(() => 0)).to.eventually.rejectedWith('Timed out'),
             ]);
             expect(step.mochaCtx.timeout()).to.be.approximately(
                 1_000 + Steps.timeDilation * (+4 * TIMEOUT + 4 * SAFETY_MARGIN),
@@ -62,7 +62,7 @@ describe('withSteps', () => {
                 method(a: number, b: string) {
                     this.a = a;
                     this.b = b;
-                }
+                },
             };
         });
         it(
@@ -114,7 +114,7 @@ describe('withSteps', () => {
                     })
                 ).to.eql({
                     callArgs: ['success'],
-                    returned: 'action!'
+                    returned: 'action!',
                 });
             })
         );

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -46,9 +46,9 @@ describe('withSteps', () => {
         it(
             'fulfils the promise in the allotted time',
             withSteps(async ({ sleep, withTimeout }) => {
-                expect(
-                    await withTimeout(sleep(SHORT_TIME * Steps.timeDilation).then(() => 'success')).timeout(LONG_TIME)
-                ).to.equal('success');
+                expect(await withTimeout(sleep(SHORT_TIME).then(() => 'success')).timeout(LONG_TIME)).to.equal(
+                    'success'
+                );
             })
         );
     });


### PR DESCRIPTION
- fix: mocha-play issue running tests with sleep
- fix: dangling promise in waitForCall
- chore: improved getIntervalPerformance