### PR TITLE
fix: beforeEach mocha ctx bug

### DIFF
--- a/packages/testing/src/mocha-ctx.ts
+++ b/packages/testing/src/mocha-ctx.ts
@@ -1,13 +1,14 @@
-import { setFirstHook, _beforeEach } from './mocha-helpers';
+import { forEach } from '@wixc3/common';
+import { getCtxRoot, getMochaRunnables, _beforeEach, _before } from './mocha-helpers';
 import { timeDilation } from './time-dilation';
 
-let currentTest: Mocha.Test;
+let currentMochaCtx: Mocha.Context | undefined;
 
 /**
  * Active mocha context
  */
-export function mochaCtx(): Mocha.Context|undefined {
-    return currentTest?.ctx;
+export function mochaCtx() {
+    return currentMochaCtx;
 }
 
 /**
@@ -18,22 +19,28 @@ export function adjustTestTime(ms: number, allowTimeDilation = true) {
     if (allowTimeDilation) {
         ms *= timeDilation();
     }
-    const ctx = mochaCtx()
+    const ctx = mochaCtx();
     ctx?.timeout(ctx?.timeout() + ms);
     return ms;
 }
 
 /**
- * Creates a playwright locator options with timeout 
+ * Creates a playwright locator options with timeout
  * and adjust the current test timeout accordingly
  */
-export function locatorTimeout(ms=1_000) {
-    return {timeout:adjustTestTime(ms)}
+export function locatorTimeout(ms = 1_000) {
+    return { timeout: adjustTestTime(ms) };
 }
 
 function saveMochaCtx(this: Mocha.Context) {
-    currentTest = this.currentTest!;
+    const root = getCtxRoot(this);
+    forEach(getMochaRunnables(root), (rn) => {
+        const fn = rn.fn as Mocha.AsyncFunc;
+        rn.fn = function (this: Mocha.Context) {
+            currentMochaCtx = rn.ctx || this;
+            return fn.call(this);
+        };
+    });
 }
 
-_beforeEach('save current test context', saveMochaCtx);
-setFirstHook(saveMochaCtx);
+_before('wrap mocha runnables to save ctx', saveMochaCtx);

--- a/packages/testing/src/mocha-helpers.ts
+++ b/packages/testing/src/mocha-helpers.ts
@@ -6,10 +6,10 @@ export const setFirstHook = (fn: () => void) => {
 };
 
 /** safe calls to mocha globals (noop if not running in a mocha environment) */
-export const _beforeEach = globalThis.beforeEach ? globalThis.beforeEach : () => void 0
-export const _before = globalThis.before ? globalThis.before : () => void 0
-export const _afterEach = globalThis.afterEach ? globalThis.afterEach : () => void 0
-export const _after = globalThis.after ? globalThis.after : () => void 0
+export const _beforeEach = globalThis.beforeEach ? globalThis.beforeEach : () => void 0;
+export const _before = globalThis.before ? globalThis.before : () => void 0;
+export const _afterEach = globalThis.afterEach ? globalThis.afterEach : () => void 0;
+export const _after = globalThis.after ? globalThis.after : () => void 0;
 
 _before(function () {
     const root = getCtxRoot(this);
@@ -32,5 +32,19 @@ function goFirst(hookFn: () => void, root: Mocha.Suite | undefined) {
         // @ts-ignore
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         root._beforeEach = [hook, ...root._beforeEach.filter((h) => h !== hook)];
+    }
+}
+
+export function* getMochaRunnables(root?: Mocha.Suite): Generator<Mocha.Runnable> {
+    for (const val of Object.values(root as object)) {
+        if (Array.isArray(val)) {
+            for (const v of val) {
+                if (typeof (v as { fn: any }).fn === 'function') {
+                    yield v as Mocha.Runnable;
+                } else {
+                    yield* getMochaRunnables(v as Mocha.Suite);
+                }
+            }
+        }
     }
 }

--- a/packages/testing/src/test/steps.unit.ts
+++ b/packages/testing/src/test/steps.unit.ts
@@ -67,10 +67,10 @@ describe('withTimeout step', () => {
     it('fulfils the promise in the allotted time', async () => {
         expect(await withTimeout(sleep(SHORT_TIME).then(() => 'success')).timeout(LONG_TIME)).to.equal('success');
     });
-    it('handles changes to timeout', async  ()=>{
-        await withTimeout(sleep(10)).timeout(1000).timeout(20)
-        await withTimeout(sleep(10)).timeout(2).timeout(20)
-    })
+    it('handles changes to timeout', async () => {
+        await withTimeout(sleep(10)).timeout(1000).timeout(20);
+        await withTimeout(sleep(10)).timeout(2).timeout(20);
+    });
 });
 
 describe('allWithTimeout step', () => {


### PR DESCRIPTION
When beforeEach is used with timeout steps, the mocha ctx was not always correct
symptom: all tests pass, mocha throws a timeout/done called multiple times error