### PR TITLE
fix(chai-retry-plugin): total test time and tests

### DIFF
--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -5,7 +5,7 @@ import { adjustTestTime, mochaCtx } from '../mocha-ctx';
 import { chaiMethodsThatHandleFunction } from './constants';
 import type { RetryAndAssertArguments } from './types';
 
-// Add ms to the current test time
+// Add ms to the current test timeout
 const addTimeoutSafetyMargin = (ms: number) => mochaCtx() && adjustTestTime(ms);
 
 function sleepWithSafetyMargin(ms: number): Promise<void> {

--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -1,22 +1,21 @@
 import Chai from 'chai';
-import { timeout as timeoutPromise, sleep} from 'promise-assist';
+import * as promiseHelpers from 'promise-assist';
 import { adjustTestTime, mochaCtx } from '../mocha-ctx';
 
 import { chaiMethodsThatHandleFunction } from './constants';
 import type { RetryAndAssertArguments } from './types';
-
 
 // Add ms to the current test time
 export const addTimeoutSafetyMargin = (ms: number) => mochaCtx() && adjustTestTime(ms);
 
 function sleepWithSafetyMargin(ms: number): Promise<void> {
     addTimeoutSafetyMargin(ms);
-    return sleep(ms);
+    return promiseHelpers.sleep(ms);
 }
 
 function timeoutWithSafetyMargin(promise: Promise<void>, ms: number, getTimeoutError: () => string): Promise<void> {
     addTimeoutSafetyMargin(ms);
-    return timeoutPromise(promise, ms, getTimeoutError);
+    return promiseHelpers.timeout(promise, ms, getTimeoutError);
 }
 
 export const retryFunctionAndAssertions = async (retryAndAssertArguments: RetryAndAssertArguments): Promise<void> => {

--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -6,7 +6,7 @@ import { chaiMethodsThatHandleFunction } from './constants';
 import type { RetryAndAssertArguments } from './types';
 
 // Add ms to the current test time
-export const addTimeoutSafetyMargin = (ms: number) => mochaCtx() && adjustTestTime(ms);
+const addTimeoutSafetyMargin = (ms: number) => mochaCtx() && adjustTestTime(ms);
 
 function sleepWithSafetyMargin(ms: number): Promise<void> {
     addTimeoutSafetyMargin(ms);

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -231,8 +231,9 @@ describe('chai-retry-plugin', () => {
         });
 
         it('.keys()', async () => {
-            const testArray = [{}, { a: 1, b: 2 }, { a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3, d: 4 }];
-            const { resultFunction, getCallCount } = withCallCount((count) => testArray[count - 1]);
+            const { resultFunction, getCallCount } = withCallCount((count) =>
+                count === 4 ? { a: 1, b: 2, c: 3, d: 4 } : { a: 1, b: 2, c: 3 }
+            );
 
             await expect(resultFunction).retry().to.have.keys(['a', 'b', 'c', 'd']);
             expect(getCallCount()).to.equal(4);

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -219,19 +219,15 @@ describe('chai-retry-plugin', () => {
         });
 
         it('.respondTo()', async () => {
-            class EchoService {
-                echo: (() => void) | undefined;
-            }
+            const service: { test?: () => null } = {};
 
             setTimeout(() => {
-                EchoService.prototype.echo = () => {
-                    return;
-                };
+                service.test = () => null;
             }, 900);
 
-            await expect(() => new EchoService(), 'should respond')
+            await expect(() => service, 'should respond')
                 .retry({ timeout: 1000 })
-                .to.respondTo('echo');
+                .to.respondTo('test');
         });
 
         it('.keys()', async () => {

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -58,6 +58,18 @@ describe('chai-retry-plugin', () => {
                 expect(getCallCount()).to.be.within(9, 10);
             }
         });
+
+        it(`should work when mocha's timeout less then time needed for test`, async function () {
+            this.timeout(100);
+            const { resultFunction } = withCallCount((callCount: number) => {
+                if (callCount < 3) {
+                    throw new Error('Failed');
+                }
+                return 'Success';
+            });
+
+            await expect(resultFunction).to.retry({ delay: 200 }).to.equal('Success');
+        });
     });
 
     describe('should work with negated assertions:', () => {

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -231,11 +231,11 @@ describe('chai-retry-plugin', () => {
         });
 
         it('.keys()', async () => {
-            const arrayWithKeys = [{}, {}, {}, { a: 1, b: 2 }, { a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3, d: 4 }];
-            const { resultFunction, getCallCount } = withCallCount((count) => arrayWithKeys[count]);
+            const testArray = [{}, { a: 1, b: 2 }, { a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3, d: 4 }];
+            const { resultFunction, getCallCount } = withCallCount((count) => testArray[count - 1]);
 
             await expect(resultFunction).retry().to.have.keys(['a', 'b', 'c', 'd']);
-            expect(getCallCount()).to.equal(5);
+            expect(getCallCount()).to.equal(4);
         });
     });
 });

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -217,6 +217,30 @@ describe('chai-retry-plugin', () => {
             await expect(resultFunction).retry().to.not.change(myObj, 'comas');
             expect(getCallCount()).to.equal(2);
         });
+
+        it('.respondTo()', async () => {
+            class EchoService {
+                echo: (() => void) | undefined;
+            }
+
+            setTimeout(() => {
+                EchoService.prototype.echo = () => {
+                    return;
+                };
+            }, 900);
+
+            await expect(() => new EchoService(), 'should respond')
+                .retry({ timeout: 1000 })
+                .to.respondTo('echo');
+        });
+
+        it('.keys()', async () => {
+            const arrayWithKeys = [{}, {}, {}, { a: 1, b: 2 }, { a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3, d: 4 }];
+            const { resultFunction, getCallCount } = withCallCount((count) => arrayWithKeys[count]);
+
+            await expect(resultFunction).retry().to.have.keys(['a', 'b', 'c', 'd']);
+            expect(getCallCount()).to.equal(5);
+        });
     });
 });
 

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -59,7 +59,7 @@ describe('chai-retry-plugin', () => {
             }
         });
 
-        it(`should work when mocha's timeout less then time needed for test`, async function () {
+        it(`should extend total test timeout`, async function () {
             this.timeout(100);
             const { resultFunction } = withCallCount((callCount: number) => {
                 if (callCount < 3) {


### PR DESCRIPTION
Improvements for `chai-retry-plugin`:

- total test time should be adjusted according to all timeouts and delays
- cover more `chai`'s build-in asserters in tests