### PR TITLE
fix(chai-retry-plugin): wrong error message

### DIFF
--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -59,7 +59,9 @@ export const retryFunctionAndAssertions = async (retryAndAssertArguments: RetryA
             }
         }
 
-        throw new Error(`Limit of ${retries} retries exceeded! ${assertionError}`);
+        if (!isTimeoutExceeded) {
+            throw new Error(`Limit of ${retries} retries exceeded! ${assertionError}`);
+        }
     };
 
     const getTimeoutError = () =>


### PR DESCRIPTION
Fixed issue with wrong error message when timeout exceeded