### PR TITLE
chore: debiug mode support in chai retry plugin

### DIFF
--- a/packages/testing/src/debug-tests.ts
+++ b/packages/testing/src/debug-tests.ts
@@ -1,3 +1,4 @@
+import { mochaCtx } from './mocha-ctx';
 import { timeDilation } from './time-dilation';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -7,4 +8,8 @@ if (debug === 'true' || parseInt(debug || '0') > 0) {
     console.log('Testing in debug mode');
     timeDilation(Number.POSITIVE_INFINITY);
     (globalThis as { mocha?: Mocha })?.mocha?.timeout(Number.POSITIVE_INFINITY);
+}
+
+export function isDebugMode() {
+    return debug || mochaCtx()?.timeout() === 0;
 }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -37,3 +37,4 @@ export * from './randomize-tests-order';
 export * from './mocha-ctx';
 export * from './time-dilation';
 export * from './chai-retry-plugin';
+export * from './debug-tests';

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -285,6 +285,18 @@ describe('chai-retry-plugin', () => {
             expect(this.timeout(), 'test timeout').to.be.approximately(BASE_TIMEOUT + SUCCESS_TIME, 10);
         });
     });
+
+    describe('debug mode - mocha test time is 0', () => {
+        it('does not time out', async () => {
+            await expect(() => sleep(50).then(() => true), 'should not time out').retry({ timeout: 10 }).to.be.true;
+        }).timeout(0);
+        it('does not stop after the max retries', async () => {
+            let count = 0;
+            await expect(() => count++, 'should not stop retrying')
+                .retry({ retries: 10 })
+                .to.eql(12);
+        }).timeout(0);
+    });
 });
 
 const withCallCount = (func: (callCount: number) => unknown) => {


### PR DESCRIPTION
in debug mode (mocha test timeout is 0 or env DEBUG=true|positive number)
timeout and retry count are ignored - making breakpoints useful 