### PR TITLE
fix: isErrorLikeObject(new Error()) should return true

### DIFF
--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from './objects';
+import { isObject } from './objects';
 
 /**
  * Convert any kind of value to an error instance. Unless the value is already
@@ -16,6 +16,18 @@ export function getErrorCode(error: Error & { code?: string }): string | undefin
 }
 
 /**
+ * Creates an error with error code. Helpful when `instanceof` can't be used
+ * because the error was serialized and then deserialized.
+ * @example
+ * ```ts
+ * try {
+ *     throw new ErrorWithCode('message', { code: 'ENOENT' });
+ * } catch (error) {
+ *     if (getErrorCode(toError(error)) === 'ENOENT') {
+ *         // ...
+ *     }
+ * }
+ * ```
  */
 export class ErrorWithCode extends Error {
     public code?: string;
@@ -66,10 +78,12 @@ export function errorToPlainObject<T extends Error>(error: T) {
     };
 }
 
+/**
+ * Checks if the `error` is an object compatible with the Error interface; that is,
+ * it has properties 'name' and 'message' of type string. The object could be an
+ * instance of an Error, or it could be some other kind of object that has these
+ * properties.
+ */
 export function isErrorLikeObject(error: unknown): error is Error {
-    return (
-        isPlainObject(error) &&
-        typeof (error as { name?: string }).name === 'string' &&
-        typeof (error as { message?: string }).message === 'string'
-    );
+    return isObject(error) && typeof error.name === 'string' && typeof error.message === 'string';
 }

--- a/packages/common/src/objects.ts
+++ b/packages/common/src/objects.ts
@@ -59,6 +59,26 @@ export function mapKeys<T extends object, R extends string>(
 }
 
 /**
+ * Checks if value is an object, e.g. a plain object, an array, a function,
+ * a regex, but not a primitive value.
+ *
+ * Common usage scenario:
+ * ```ts
+ * declare const value: unknown;
+ *
+ * // Type error: property 'foo' does not exist on type 'object'.
+ * typeof value === 'object' && value !== null && value.foo === 'bar';
+ *
+ *  // No type error.
+ * isObject(value) && value.foo === 'bar';
+ * ```
+ */
+export function isObject(value: unknown): value is Record<string | number | symbol, unknown> {
+    const type = typeof value;
+    return value !== null && (type === 'object' || type === 'function');
+}
+
+/**
  * Checks that value is a POJO
  */
 export function isPlainObject(value: unknown): value is Record<string | number | symbol, unknown> {

--- a/packages/common/src/objects.ts
+++ b/packages/common/src/objects.ts
@@ -64,16 +64,12 @@ export function mapKeys<T extends object, R extends string>(
  *
  * Common usage scenario:
  * ```ts
- * declare const value: unknown;
- *
- * // Type error: property 'foo' does not exist on type 'object'.
- * typeof value === 'object' && value !== null && value.foo === 'bar';
- *
- *  // No type error.
  * isObject(value) && value.foo === 'bar';
+ * // Instead of:
+ * typeof value === 'object' && value !== null && 'foo' in value && value.foo === 'bar';
  * ```
  */
-export function isObject(value: unknown): value is Record<string | number | symbol, unknown> {
+export function isObject(value: unknown): value is Readonly<Record<string | number | symbol, unknown>> {
     const type = typeof value;
     return value !== null && (type === 'object' || type === 'function');
 }

--- a/packages/common/src/test/errors.unit.ts
+++ b/packages/common/src/test/errors.unit.ts
@@ -1,0 +1,21 @@
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import { isErrorLikeObject } from '../errors';
+chai.use(sinonChai);
+
+describe('isErrorLikeObject', () => {
+    it('returns true for instances of Error', () => {
+        const error = new Error();
+        expect(isErrorLikeObject(error)).equal(true);
+    });
+
+    it('returns true for objects that satisfy the Error interface', () => {
+        const error = {name: 'RangeError', message: 'The value is out of range'};
+        expect(isErrorLikeObject(error)).equal(true);
+    });
+
+    it(`returns false for objects that don't satisfy the Error interface`, () => {
+        const error = {name: undefined, message: 'The value is out of range'};
+        expect(isErrorLikeObject(error)).equal(false);
+    });
+});


### PR DESCRIPTION
1. Fixed `isErrorLikeObject()` and added tests:

   ```ts
   // Before
   isErrorLikeObject(new Error()) // => false
   
   // After
   isErrorLikeObject(new Error()) // => true

2. Added a function `isObject()` identical to `_.isObject()` from Lodash (not the same as `isPlainObject`).

3. Added descriptions for `ErrorWithCode` and `isErrorLikeObject`.