### PR TITLE
fix: remove signal unsubscribe return

### DIFF
--- a/packages/patterns/src/signal.ts
+++ b/packages/patterns/src/signal.ts
@@ -39,11 +39,9 @@ export class Signal<T> extends Set<Listener<T>> {
      */
     subscribe = (handler: Listener<T>) => {
         this.add(handler);
-        return () => this.unsubscribe(handler);
     };
     once = (handler: Listener<T>) => {
         this.onceHandlers.add(handler);
-        return () => this.unsubscribe(handler);
     };
 
     /**

--- a/packages/patterns/src/test/signal.unit.ts
+++ b/packages/patterns/src/test/signal.unit.ts
@@ -67,12 +67,6 @@ describe('Signal', () => {
         signal.notify({ a: 'value', b: 5 });
         expect(listener.callCount, 'no new calls after unsubscribe').to.eql(0);
     });
-    it(`doesn't call listeners after unsubscribing using subscribe return value`, () => {
-        const unsubscribe = signal.subscribe(listener);
-        unsubscribe();
-        signal.notify({ a: 'value', b: 5 });
-        expect(listener.callCount, 'no new calls after unsubscribe').to.eql(0);
-    });
     describe('clear', () => {
         it('removes all listeners', () => {
             signal.subscribe(listener);


### PR DESCRIPTION
This PR removes a nice to have feature that was added as part of #701. The feature improved the `Signal` class by returning an `unsubscribe()` method that could be called to reverse the registration. However, this change, which might still be added in the future, is breaking in unintended ways and needs to be introduced more carefully.