### PR TITLE
feature(retry-plugin): add meaningful error stacks

### DIFF
--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -43,7 +43,7 @@ export const retryFunctionAndAssertions = async (retryParams: RetryAndAssertArgu
         throw new Error(`Limit of ${options.retries} retries exceeded! ${assertionError}`);
     };
 
-    const getTimeoutError = () => `Timed out after ${options.timeout}ms. ${assertionError ?? ''}`;
+    const getTimeoutError = () => `Timed out after ${options.timeout}ms.`;
 
     if (isDebugMode()) {
         return performRetries();
@@ -51,6 +51,12 @@ export const retryFunctionAndAssertions = async (retryParams: RetryAndAssertArgu
         return timeout(performRetries(), options.timeout, getTimeoutError).catch((err) => {
             cancel();
             didTimeout = true;
+            if (err instanceof Error) {
+                const retryStack = new Error().stack;
+                const assertionStack = assertionError?.stack;
+
+                err.stack = '\nRetry stack:\n\n' + retryStack + '\n\nAssertion stack:\n\n' + assertionStack;
+            }
             throw err;
         });
     }

--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -58,7 +58,8 @@ describe('chai-retry-plugin', () => {
             try {
                 await expect(resultFunction).retry({ delay: 50, timeout: 500 }).to.equal(5);
             } catch (error: unknown) {
-                expect((error as Error).message).includes('Timed out after 500ms. Error: Im throwing');
+                expect((error as Error).message).includes('Timed out after 500ms.');
+                expect((error as Error).stack).includes('Error: Im throwing');
                 expect(getCallCount()).to.be.within(8, 10);
             }
         });


### PR DESCRIPTION
This is before:

<img width="761" alt="Screenshot 2023-12-18 at 22 07 04" src="https://github.com/wixplosives/core3-utils/assets/645678/d61b2cad-6349-427f-95c8-b4eac36c879e">

And these are after:

* This is how it would look like when expectation would not resolve/reject during retry timeout: 
  <img width="940" alt="Screenshot 2023-12-18 at 21 52 13" src="https://github.com/wixplosives/core3-utils/assets/645678/14f3f77b-eae7-44da-93a6-95ea44dadcfc">
* This is how it would look like when there's an Error with custom message is thrown inside retries:
  <img width="953" alt="Screenshot 2023-12-18 at 21 52 44" src="https://github.com/wixplosives/core3-utils/assets/645678/34281226-c442-4bad-87b8-665f7b4b0867">
* This is how it would look like when just chai expectation would fail during retries:
  <img width="757" alt="Screenshot 2023-12-18 at 21 53 18" src="https://github.com/wixplosives/core3-utils/assets/645678/f165763c-1f03-4e56-9f40-b4fac41604b9">
