### PR TITLE
fix: commented "using" keyword (not supported in browsers yet)

### DIFF
--- a/packages/patterns/src/disposables/create-disposables.ts
+++ b/packages/patterns/src/disposables/create-disposables.ts
@@ -72,10 +72,7 @@ export function createDisposables(name: string, initialGroups: string[] = []) {
 export class Disposables {
     private readonly groups: DisposalGroup[] = [createGroup(DEFAULT_GROUP)];
     private readonly constrains: GroupConstraints[] = [];
-    constructor(
-        private name: string,
-        initialGroups: string[] = [],
-    ) {
+    constructor(private name: string, initialGroups: string[] = []) {
         this.dispose = this.dispose.bind(this);
         this.groups.push(...initialGroups.map(createGroup));
     }
@@ -104,17 +101,23 @@ export class Disposables {
             this.registerGroup(groupName, constraints);
         }
     }
-
     /**
-     * @param disposable a function or object with a dispose method
-     * @param options if string, will be used as group name
+     * @param name - disposable name for error messages
+     * @param disposable - a function or object with a dispose method
      * @returns a function to remove the disposable
      */
+    add(name: string, disposable: DisposableItem): () => void;
+    /**
+     * @param options must include a [dispose] function or object with a dispose method
+     * @returns a function to remove the disposable
+     */
+    add(options: DisposableOptions): () => void;
+    // @internal
     add(...[nameOrOptions, disposable]: [id: string, disposable: DisposableItem] | [options: DisposableOptions]) {
         if (typeof nameOrOptions === 'string') {
             if (!disposable) {
                 throw new Error(
-                    `Invalid disposable: must be a function or object with a dispose method got ${disposable}`,
+                    `Invalid disposable: must be a function or object with a dispose method got ${disposable}`
                 );
             }
             nameOrOptions = { name: nameOrOptions, dispose: disposable };

--- a/packages/patterns/src/disposables/create-disposables.ts
+++ b/packages/patterns/src/disposables/create-disposables.ts
@@ -72,7 +72,10 @@ export function createDisposables(name: string, initialGroups: string[] = []) {
 export class Disposables {
     private readonly groups: DisposalGroup[] = [createGroup(DEFAULT_GROUP)];
     private readonly constrains: GroupConstraints[] = [];
-    constructor(private name: string, initialGroups: string[] = []) {
+    constructor(
+        private name: string,
+        initialGroups: string[] = [],
+    ) {
         this.dispose = this.dispose.bind(this);
         this.groups.push(...initialGroups.map(createGroup));
     }
@@ -117,7 +120,7 @@ export class Disposables {
         if (typeof nameOrOptions === 'string') {
             if (!disposable) {
                 throw new Error(
-                    `Invalid disposable: must be a function or object with a dispose method got ${disposable}`
+                    `Invalid disposable: must be a function or object with a dispose method got ${disposable}`,
                 );
             }
             nameOrOptions = { name: nameOrOptions, dispose: disposable };

--- a/packages/patterns/src/disposables/safe-disposable.ts
+++ b/packages/patterns/src/disposables/safe-disposable.ts
@@ -36,9 +36,12 @@ type GUARDED_FN<T> = GUARDED_FN_SYNC<T> | GUARDED_FN_ASYNC<T>;
  *
  *     async doSomething() {
  *         // will throw if disposed, delays disposal until done is called
- *         using _ = this.disposables.guard()
- *         await somePromise // if dispose is called while the code awaits, new guards will throw, but actual disposal will not begin
- *     } // after the method exists, disposal may begin
+ *         await this.disposables.guard(() =>{
+ *              // do something
+ *              await somePromise // if dispose is called while the code awaits, new guards will throw, but actual disposal will not begin
+ *         })
+ *         // disposal may begin
+ *     } 
  * }
  * ```
  */
@@ -129,6 +132,7 @@ export class SafeDisposable extends Disposables implements IDisposable {
         canDispose.then(removeGuard, removeGuard);
 
         return executeCode(fn, done);
+
         /**
          * Support for the "using" keyword
          * uncomment when supported in browsers

--- a/packages/patterns/src/disposables/safe-disposable.ts
+++ b/packages/patterns/src/disposables/safe-disposable.ts
@@ -36,9 +36,9 @@ type GUARDED_FN<T> = GUARDED_FN_SYNC<T> | GUARDED_FN_ASYNC<T>;
  *
  *     async doSomething() {
  *         // will throw if disposed, delays disposal until done is called
- *         await this.disposables.guard(() =>{
+ *         return await this.disposables.guard(async () =>{
  *              // do something
- *              await somePromise // if dispose is called while the code awaits, new guards will throw, but actual disposal will not begin
+ *              return await somePromise // if dispose is called while the code awaits, new guards will throw, but actual disposal will not begin
  *         })
  *         // disposal may begin
  *     } 
@@ -217,5 +217,11 @@ function executeCode<T>(fn: GUARDED_FN<T> | null, done: () => void) {
 
         return result.finally(done);
     }
+    /**
+     * Support for the "using" keyword
+     * uncomment when supported in browsers
+     */
+    // return
+    // TODO remove when "using" is supported in browsers
     return done();
 }

--- a/packages/patterns/src/disposables/safe-disposable.ts
+++ b/packages/patterns/src/disposables/safe-disposable.ts
@@ -11,6 +11,12 @@ const DISPOSAL_GUARD_DEFAULTS = {
     timeout: 5_000,
     usedWhileDisposing: false,
 };
+
+type OPTIONS = Partial<typeof DISPOSAL_GUARD_DEFAULTS>;
+type GUARDED_FN_ASYNC<T> = () => Promise<T>;
+type GUARDED_FN_SYNC<T> = () => T;
+type GUARDED_FN<T> = GUARDED_FN_SYNC<T> | GUARDED_FN_ASYNC<T>;
+
 /**
  * Adds dispose-safe methods to Disposables:
  *
@@ -88,34 +94,27 @@ export class SafeDisposable extends Disposables implements IDisposable {
      *
      * - throws if disposal started/finished
      * - delays disposal actual until the current flow is done
-     * @example with "using" keyword
-     * ```ts
-     * {
-     *      // this will throw if disposed
-     *      using _ = this.guard({timeout: 1000, name:'something'});
-     *      // do something
-     * }
-     * // disposal may begin
-     * ```
      *
-     * @example without THE "using" keyword
+     * @example
      * ```ts
      *  // this will throw if disposed
-     * const done = this.guard({timeout: 1000, name:'something'});
-     * try {
-     *    // do something
-     * } finally {
-     *    // disposal can begin (if dispose was called)
-     *    done();
-     *    // disposal may begin
-     * }
+     *  this.guard(()=> {
+     *      // do something
+     *      // if dispose is called while the code executes,
+     *      // new guards will throw, but actual disposal will not begin
+     *  }, {timeout: 1000, name:'something'});
+     *  // disposal may begin
      * ```
      */
-    guard(options?: Partial<typeof DISPOSAL_GUARD_DEFAULTS>) {
-        const { usedWhileDisposing, name, timeout } = {
-            ...DISPOSAL_GUARD_DEFAULTS,
-            ...(options ?? {}),
-        };
+    guard<T>(fn: GUARDED_FN_ASYNC<T>, options?: OPTIONS): Promise<T>;
+    guard<T>(fn: GUARDED_FN_SYNC<T>, options?: OPTIONS): T;
+    guard<_T>(options?: OPTIONS): { [Symbol.dispose]: () => void };
+    // @internal
+    guard<T>(fnOrOptions?: OPTIONS | GUARDED_FN<T>, options?: OPTIONS) {
+        const {
+            fn,
+            options: { name, timeout, usedWhileDisposing },
+        } = extractArgs<T>(fnOrOptions, options);
 
         if (this.isDisposed && !(this._isDisposing && usedWhileDisposing)) {
             throw new Error('Instance was disposed');
@@ -129,7 +128,12 @@ export class SafeDisposable extends Disposables implements IDisposable {
         });
         canDispose.then(removeGuard, removeGuard);
 
-        return Object.assign(done, { [Symbol.dispose]: done });
+        return executeCode(fn, done);
+        /**
+         * Support for the "using" keyword
+         * uncomment when supported in browsers
+         */
+        // || { [Symbol.dispose]: done };
     }
 
     /**
@@ -137,15 +141,16 @@ export class SafeDisposable extends Disposables implements IDisposable {
      * checks disposal before execution and clears the timeout when the instance is disposed
      */
     setTimeout(fn: () => void, timeout: number): ReturnType<typeof setTimeout> {
-        using _ = this.guard();
-        const handle = setTimeout(() => {
-            this.timeouts.delete(handle);
-            if (!this.isDisposed) {
-                fn();
-            }
-        }, timeout);
-        this.timeouts.add(handle);
-        return handle;
+        return this.guard(() => {
+            const handle = setTimeout(() => {
+                this.timeouts.delete(handle);
+                if (!this.isDisposed) {
+                    fn();
+                }
+            }, timeout);
+            this.timeouts.add(handle);
+            return handle;
+        });
     }
 
     /**
@@ -153,18 +158,59 @@ export class SafeDisposable extends Disposables implements IDisposable {
      * checks disposal before execution and clears the interval when the instance is disposed
      */
     setInterval(fn: () => void, interval: number): ReturnType<typeof setInterval> {
-        using _ = this.guard();
-        const handle = setInterval(() => {
-            if (!this.isDisposed) {
-                fn();
-            }
-        }, interval);
-        this.intervals.add(handle);
-        return handle;
+        return this.guard(() => {
+            const handle = setInterval(() => {
+                if (!this.isDisposed) {
+                    fn();
+                }
+            }, interval);
+            this.intervals.add(handle);
+            return handle;
+        });
     }
 
     /**
      * Support for the "using" keyword
+     * uncomment when supported in browsers
      */
-    [Symbol.asyncDispose] = () => this.dispose();
+    // [Symbol.asyncDispose] = () => this.dispose();
+}
+
+function extractArgs<T>(fnOrOptions?: OPTIONS | GUARDED_FN<T>, options?: OPTIONS) {
+    if (fnOrOptions instanceof Function) {
+        return {
+            fn: fnOrOptions,
+            options: {
+                ...DISPOSAL_GUARD_DEFAULTS,
+                ...(options ?? {}),
+            },
+        };
+    } else {
+        return {
+            fn: null,
+            options: {
+                ...DISPOSAL_GUARD_DEFAULTS,
+                ...(fnOrOptions ?? {}),
+            },
+        };
+    }
+}
+
+function executeCode<T>(fn: GUARDED_FN<T> | null, done: () => void) {
+    let result: T | Promise<T>;
+    if (fn) {
+        try {
+            result = fn();
+            if (!(result instanceof Promise)) {
+                done();
+                return result;
+            }
+        } catch (e) {
+            done();
+            throw e;
+        }
+
+        return result.finally(done);
+    }
+    return;
 }

--- a/packages/patterns/src/disposables/safe-disposable.ts
+++ b/packages/patterns/src/disposables/safe-disposable.ts
@@ -111,7 +111,8 @@ export class SafeDisposable extends Disposables implements IDisposable {
      */
     guard<T>(fn: GUARDED_FN_ASYNC<T>, options?: OPTIONS): Promise<T>;
     guard<T>(fn: GUARDED_FN_SYNC<T>, options?: OPTIONS): T;
-    guard<_T>(options?: OPTIONS): { [Symbol.dispose]: () => void };
+    guard<_T>(options?: OPTIONS): void;
+    // guard<T>(options?: OPTIONS): { [Symbol.dispose]: () => void };
     // @internal
     guard<T>(fnOrOptions?: OPTIONS | GUARDED_FN<T>, options?: OPTIONS) {
         const {
@@ -216,5 +217,5 @@ function executeCode<T>(fn: GUARDED_FN<T> | null, done: () => void) {
 
         return result.finally(done);
     }
-    return;
+    return done();
 }

--- a/packages/patterns/src/test/safe-disposable.unit.ts
+++ b/packages/patterns/src/test/safe-disposable.unit.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { SafeDisposable } from '../disposables/safe-disposable';
 import { deferred, sleep } from 'promise-assist';
-import sinon from 'sinon';
 
 describe('SafeDisposable class', () => {
     describe('dispose', () => {
@@ -38,7 +37,13 @@ describe('SafeDisposable class', () => {
                 expect(() => disposable.guard({ usedWhileDisposing: true })).to.throw('Instance was disposed');
             });
         });
-        describe('sync/async', () => {
+        /*
+            The following suite tests the behavior of the "using" keyword, 
+            which is not supported in browsers.
+            Uncomment when they are supported.
+
+
+        describe('sync/async with "using" keyword', () => {
             it('sync does not delay disposal', async () => {
                 const disposable = new SafeDisposable('name');
                 let disposeCalled = false;
@@ -54,7 +59,7 @@ describe('SafeDisposable class', () => {
 
                 await disposing;
             });
-            it('async (default) delays disposal until the guard is done', async () => {
+            it('async delays disposal until the guard is done', async () => {
                 const disposables = new SafeDisposable('test');
                 let disposeCalled = false;
                 disposables.add('disposeCalled', () => {
@@ -70,6 +75,45 @@ describe('SafeDisposable class', () => {
                     expect(disposables.isDisposed, 'isDisposed').to.be.true;
                     expect(disposeCalled, 'disposeCalled').to.be.false;
                 }
+                await disposing;
+                expect(disposeCalled, 'disposeCalled after done()').to.be.true;
+            });
+        });
+        */
+        describe('sync/async without "using" keyword', () => {
+            it('sync does not delay disposal', async () => {
+                const disposable = new SafeDisposable('name');
+                let disposeCalled = false;
+                disposable.add('disposeCalled', () => {
+                    disposeCalled = true;
+                });
+                expect(
+                    disposable.guard(() => 'guarded return value'),
+                    'guard return value',
+                ).to.eql('guarded return value');
+                const disposing = disposable.dispose();
+                await sleep(1);
+                expect(disposeCalled).to.be.true;
+
+                await disposing;
+            });
+            it('async delays disposal until the guard is done', async () => {
+                const disposables = new SafeDisposable('test');
+                let disposeCalled = false;
+                disposables.add('disposeCalled', () => {
+                    disposeCalled = true;
+                });
+
+                let disposing!: Promise<void>;
+                const result = disposables.guard(async () => {
+                    disposing = disposables.dispose();
+                    await sleep(1);
+
+                    expect(disposables.isDisposed, 'isDisposed').to.be.true;
+                    expect(disposeCalled, 'disposeCalled').to.be.false;
+                    return 'guarded return value';
+                });
+                expect(await result, 'guard return value').to.eql('guarded return value');
                 await disposing;
                 expect(disposeCalled, 'disposeCalled after done()').to.be.true;
             });
@@ -113,14 +157,14 @@ describe('SafeDisposable class', () => {
             expect(triggerCount).to.equal(0);
         });
     });
-    describe('"using" keyword', () => {
-        it('disposes when the using block exists', async () => {
-            const spy = sinon.spy();
-            {
-                await using disposable = new SafeDisposable('test');
-                disposable.add('wasDisposed', spy);
-            }
-            expect(spy.callCount).to.equal(1);
-        });
-    });
+    // describe('"using" keyword', () => {
+    //     it('disposes when the using block exists', async () => {
+    //         const spy = sinon.spy();
+    //         {
+    //             await using disposable = new SafeDisposable('test');
+    //             disposable.add('wasDisposed', spy);
+    //         }
+    //         expect(spy.callCount).to.equal(1);
+    //     });
+    // });
 });

--- a/packages/patterns/src/test/safe-disposable.unit.ts
+++ b/packages/patterns/src/test/safe-disposable.unit.ts
@@ -37,6 +37,14 @@ describe('SafeDisposable class', () => {
                 expect(() => disposable.guard({ usedWhileDisposing: true })).to.throw('Instance was disposed');
             });
         });
+        describe('when no function is passed', () => {
+            it('it does not block disposal', async () => {
+                const disposable = new SafeDisposable('test');
+                disposable.guard();
+                await disposable.dispose();
+            });
+        });
+
         /*
             The following suite tests the behavior of the "using" keyword, 
             which is not supported in browsers.

--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -19,7 +19,7 @@ const filterAssertionStack = (stack: string | undefined) =>
                     'performRetries',
                     'process.processTimers',
                     'runNextTicks',
-                ].some((hiddenMethods) => row.trim().startsWith(`at ${hiddenMethods}`))
+                ].some((hiddenMethods) => row.trim().startsWith(`at ${hiddenMethods}`)),
         )
         .join('\n');
 


### PR DESCRIPTION
Since the "using" keyword is only supported in node, commented out all `using` `Symbol.dispose` and `Symbol.asyncDispose` usages and tests