### PR TITLE
fix: behavior/performance issues when creating error with every disposal add.

### DIFF
--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -93,21 +93,3 @@ export const TRACE_DEFAULTS = {
     skipLines: 2,
     filterPattern: null as RegExp | null,
 };
-
-export function getStackTrace(options: Partial<typeof TRACE_DEFAULTS> = TRACE_DEFAULTS) {
-    const { filterPattern, noTraceMessage, skipLines } = { ...TRACE_DEFAULTS, ...options };
-    const { stack } = new Error();
-    return (
-        stack
-            ?.split('\n')
-            .slice(skipLines)
-            .filter((l) => (filterPattern ? filterPattern.test(l) : true))
-            .join('\n') ?? noTraceMessage
-    );
-}
-
-export function errorWithTrace(message: string, trace: string, options?: ErrorOptions) {
-    const err = new Error(message, options);
-    err.stack = (err.stack?.split('\n')[0] ?? `Error: ${message}`) + '\n' + trace;
-    return err;
-}

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -87,9 +87,3 @@ export function errorToPlainObject<T extends Error>(error: T) {
 export function isErrorLikeObject(error: unknown): error is Error {
     return isObject(error) && typeof error.name === 'string' && typeof error.message === 'string';
 }
-
-export const TRACE_DEFAULTS = {
-    noTraceMessage: 'no stack trace',
-    skipLines: 2,
-    filterPattern: null as RegExp | null,
-};

--- a/packages/common/src/test/errors.unit.ts
+++ b/packages/common/src/test/errors.unit.ts
@@ -1,7 +1,6 @@
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
-import { isErrorLikeObject, getStackTrace, errorWithTrace } from '../errors';
-import { deferred } from 'promise-assist';
+import { isErrorLikeObject } from '../errors';
 
 chai.use(sinonChai);
 
@@ -19,41 +18,5 @@ describe('isErrorLikeObject', () => {
     it(`returns false for objects that don't satisfy the Error interface`, () => {
         const error = { name: undefined, message: 'The value is out of range' };
         expect(isErrorLikeObject(error)).equal(false);
-    });
-});
-
-describe('getStackTrace', () => {
-    it('default', () => {
-        const stack = getStackTrace();
-
-        expect(stack.split('\n')[0]).to.match(/.*errors\.unit\.ts/);
-    });
-    it('removes this package internals from stacktrace', () => {
-        const stack = getStackTrace({ skipLines: 1 });
-
-        expect(stack.split('\n')[0]).to.match(/.*errors\.ts/);
-    });
-    it(`removes lines that don't match filterPattern`, () => {
-        const stack = getStackTrace({ filterPattern: /.*errors\.unit\.ts/ });
-        expect(stack.split('\n')).to.have.lengthOf(1);
-        expect(stack).to.match(/.*errors\.unit\.ts/);
-    });
-});
-
-describe('errorWithTrace', () => {
-    it('returns an error has the given stack trace', async () => {
-        const trace = getStackTrace();
-        const err = deferred<Error>();
-        setTimeout(() => {
-            try {
-                throw errorWithTrace('err', trace, { cause: 'test' });
-            } catch (e) {
-                err.resolve(e as Error);
-            }
-        }, 1);
-        const { stack, message, cause } = await err.promise;
-        expect(stack).to.match(/Error: err\n\s+at Context\.<anonymous>.*errors\.unit\.ts.*\n/);
-        expect(message).to.equal('err');
-        expect(cause).to.equal('test');
     });
 });

--- a/packages/patterns/src/disposables/create-disposables.ts
+++ b/packages/patterns/src/disposables/create-disposables.ts
@@ -1,4 +1,3 @@
-import { getStackTrace } from '@wixc3/common';
 import { DisposalGroup, getGroupConstrainedIndex, GroupConstraints, normalizeConstraints } from './constraints';
 import { DisposableItem, DisposablesGroup } from './disposables-group';
 
@@ -129,7 +128,7 @@ export class Disposables {
             throw new Error(`Invalid group: "${groupName}" doesn't exists`);
         }
 
-        group.disposables.add(dispose, timeout, `[${this.name}]: ${name}`, getStackTrace({ skipLines: 3 }));
+        group.disposables.add(dispose, timeout, `[${this.name}]: ${name}`);
         return () => group.disposables.remove(dispose);
     }
 

--- a/packages/patterns/src/disposables/disposables-group.ts
+++ b/packages/patterns/src/disposables/disposables-group.ts
@@ -1,4 +1,3 @@
-import { errorWithTrace } from '@wixc3/common';
 import { timeout } from 'promise-assist';
 
 /**
@@ -15,20 +14,19 @@ export class DisposablesGroup {
                 await timeout(disposeOf(disposable), details.timeout, message(details));
             } catch (e) {
                 if ((e as Error).message === message(details)) {
-                    throw errorWithTrace(message(details), details.trace);
+                    throw e;
+                } else {
+                    throw new Error(`Disposal failed: "${details.name}"`, { cause: e });
                 }
-                throw errorWithTrace(`Disposal failed: "${details.name}"`, details.trace, {
-                    cause: e,
-                });
             }
         }
     }
 
-    add(disposable: DisposableItem, timeout: number, name: string, trace: string) {
+    add(disposable: DisposableItem, timeout: number, name: string) {
         if (this.disposables.has(disposable)) {
             throw new Error(`Disposable already added`);
         }
-        this.disposables.set(disposable, { timeout, name, trace });
+        this.disposables.set(disposable, { timeout, name });
         return () => this.disposables.delete(disposable);
     }
 
@@ -47,7 +45,6 @@ export type DisposableItem = { dispose: DisposeFunction } | DisposeFunction;
 export type NamedDisposable = {
     timeout: number;
     name: string;
-    trace: string;
 };
 
 function message(details: NamedDisposable): string {

--- a/packages/patterns/src/disposables/safe-disposable.ts
+++ b/packages/patterns/src/disposables/safe-disposable.ts
@@ -1,4 +1,3 @@
-import { errorWithTrace, getStackTrace } from '@wixc3/common';
 import { Disposables } from '.';
 import { deferred } from 'promise-assist';
 
@@ -122,7 +121,7 @@ export class SafeDisposable extends Disposables implements IDisposable {
         } = extractArgs<T>(fnOrOptions, options);
 
         if (this.isDisposed && !(this._isDisposing && usedWhileDisposing)) {
-            throw errorWithTrace('Instance was disposed', getStackTrace());
+            throw new Error('Instance was disposed');
         }
         const { promise: canDispose, resolve: done } = deferred();
         const removeGuard = this.add({

--- a/packages/patterns/src/test/disposables.unit.ts
+++ b/packages/patterns/src/test/disposables.unit.ts
@@ -50,25 +50,25 @@ describe('disposables', () => {
             const disposables = createDisposables('test');
             disposables.add({
                 name: 'disposing with error',
-                // eslint-disable-next-line @typescript-eslint/require-await
-                dispose: async () => {
+                dispose: () => {
                     throw new Error('failed!');
                 },
             });
 
+            let error: Error | undefined = undefined;
             try {
                 await disposables.dispose();
             } catch (e) {
-                const { message, stack, cause } = e as Error;
-                expect(message, 'message').to.equal('Disposal failed: "[test]: disposing with error"');
-                expect((cause as Error).message, 'cause').to.equal('failed!');
-                const [_, disposeFn, mocha] = stack?.split('\n') ?? [];
-                expect(disposeFn, 'dispose fn').to.match(/at Context\.<anonymous>.*disposables\.unit\.ts:\d+:\d+/);
-                expect(mocha, 'mocha').to.match(/at Context\.runnable\.fn/);
-                return;
+                error = e as Error;
+            }
+            if (!error) {
+                throw new Error('expected error');
             }
 
-            throw new Error('Expected error to be throws');
+            expect(error).to.be.instanceOf(Error);
+            expect(error.message).to.eql('Disposal failed: "[test]: disposing with error"');
+            expect(error.cause).to.be.instanceOf(Error);
+            expect((error.cause as Error).message).to.eql('failed!');
         });
     });
     describe('initial disposal group', () => {
@@ -96,13 +96,13 @@ describe('disposables', () => {
             it('throws for missing groups', () => {
                 const groups = createDisposables('test');
                 expect(() => groups.registerGroup('group1', { before: 'group2' })).to.throw(
-                    `Invalid constraint: "before: group2" - group not found`,
+                    `Invalid constraint: "before: group2" - group not found`
                 );
             });
             it('throws for no constraints', () => {
                 const groups = createDisposables('test');
                 expect(() => groups.registerGroup('group1', [])).to.throw(
-                    `Invalid disposal group: must have at least one constraint`,
+                    `Invalid disposal group: must have at least one constraint`
                 );
             });
             it('throws for contradictory constraints', () => {
@@ -111,13 +111,13 @@ describe('disposables', () => {
                 groups.registerGroup('after', { after: 'default' });
                 expect(() => groups.registerGroup('valid', { before: 'after', after: 'default' })).not.to.throw();
                 expect(() => groups.registerGroup('invalid', { before: 'before', after: 'after' })).to.throw(
-                    'Invalid constraints: after runs after before, which contradicts prior constraints',
+                    'Invalid constraints: after runs after before, which contradicts prior constraints'
                 );
             });
             it('requires a unique group name', () => {
                 const groups = createDisposables('test');
                 expect(() => groups.registerGroup('default', { before: 'default' })).to.throw(
-                    `Invalid group: "default" already exists`,
+                    `Invalid group: "default" already exists`
                 );
             });
         });


### PR DESCRIPTION
Starting with https://github.com/wixplosives/core3-utils/pull/718

Creating errors with each add caused a failure in our tests.

This PR reverts the behavior and compremise the error output of "during timeout errors".
But as soon as https://github.com/mochajs/mocha/pull/4829 lands,
We will have the error cause printed corrctlly  