### PR TITLE
feat(testing): make retry plugin accept async methods

### DIFF
--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -44,7 +44,7 @@ export const retryFunctionAndAssertions = async (retryParams: RetryAndAssertArgu
                 let assertion = await initialAssertion(retryParams);
 
                 for (const { propertyName, method, args } of assertionStack) {
-                    assertion = updateAssertion(method, args, assertion, propertyName);
+                    assertion = await updateAssertion(method, args, assertion, propertyName);
                 }
 
                 return;

--- a/packages/testing/src/chai-retry-plugin/helpers.ts
+++ b/packages/testing/src/chai-retry-plugin/helpers.ts
@@ -90,12 +90,12 @@ const initialAssertion = async ({ assertionStack, description, functionToRetry: 
     return Chai.expect(valueToAssert, description);
 };
 
-const updateAssertion = (
+const updateAssertion = async (
     method: AssertionMethod | undefined,
     args: unknown[] | undefined,
     assertion: Chai.Assertion,
     propertyName: keyof Chai.Assertion,
-) => (method && args ? method.apply(assertion, args) : (assertion[propertyName] as Chai.Assertion));
+) => (method && args ? await method.apply(assertion, args) : (assertion[propertyName] as Chai.Assertion));
 
 const adjustTest = (time: number, delay: number): number => {
     const now = Date.now();

--- a/packages/testing/src/chai-retry-plugin/types.ts
+++ b/packages/testing/src/chai-retry-plugin/types.ts
@@ -15,7 +15,7 @@ declare global {
     }
 }
 
-export type AssertionMethod = (...args: unknown[]) => Chai.Assertion;
+export type AssertionMethod = (...args: unknown[]) => Chai.Assertion | Promise<Chai.Assertion>;
 
 // Function provided as argument of `expect`
 export type FunctionToRetry = (...args: unknown[]) => unknown;


### PR DESCRIPTION
This PR make retry plugin work correctly with async methods.

If Chai extended with async methods like following:

`matchCode(code: string): Promise<Assertion>;`

it would give false positive:

    it('FALSE POSITIVE', async () => {
        await expect(() => `const a =    7;`)
            .retry()
            .to.matchCode(`const b = 7;`);
    });

