### PR TITLE
fix(testing): typcheck code matchers

### DIFF
--- a/packages/testing/src/chai-retry-plugin/types.ts
+++ b/packages/testing/src/chai-retry-plugin/types.ts
@@ -1,4 +1,4 @@
-import { PromiseLikeAssertion } from '../types';
+import type { PromiseLikeAssertion } from '../types';
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/testing/src/code-matchers/code-matchers.ts
+++ b/packages/testing/src/code-matchers/code-matchers.ts
@@ -6,6 +6,8 @@ import { Options } from 'prettier';
 import * as esTreePlugin from 'prettier/plugins/estree';
 import * as parserTypeScript from 'prettier/plugins/typescript';
 import { format } from 'prettier/standalone';
+// makes ts pick up global augmentation of Chai.Assertion
+import type * as _ from './types';
 
 use(chaiAsPromised);
 

--- a/packages/testing/src/code-matchers/types.ts
+++ b/packages/testing/src/code-matchers/types.ts
@@ -1,5 +1,5 @@
-import { Options } from 'prettier';
-import { PromiseLikeAssertion } from '../types';
+import type { Options } from 'prettier';
+import type { PromiseLikeAssertion } from '../types';
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace


### PR DESCRIPTION
This PR fixes the `yarn typecheck` for codux when using code-matchers from `@wixc3/testing`.

