### PR TITLE
fix: expose retry matcher last error on timeout

### DIFF
--- a/packages/testing/src/test/chai-retry-plugin.unit.ts
+++ b/packages/testing/src/test/chai-retry-plugin.unit.ts
@@ -331,12 +331,20 @@ describe('chai-retry-plugin', () => {
     describe('async assertion', () => {
         it('times out for failed async assertion', async () => {
             overrideDebugMode(false);
-            await expect(
-                expect(() => `const source = true;`)
-                    .retry({ timeout: 50 })
-                    .to.matchCode(`const expected = 'wrong';`),
-            ).to.be.rejectedWith(`Timed out after 50ms`);
+
+            const matcherToCheck = expect(() => `const source = true;`)
+                .retry({ timeout: 50 })
+                .to.equal(`const expected = "wrong";`);
+
+            await expect(matcherToCheck)
+                .to.be.rejectedWith(`Timed out after 50ms`)
+                .then((error: Error) => {
+                    expect(error.stack).to.include(
+                        `AssertionError: expected 'const source = true;' to equal 'const expected = "wrong";`,
+                    );
+                });
         });
+
         it('passes async assertion', async () => {
             await expect(() => `const source = true;`)
                 .retry({ timeout: 50 })


### PR DESCRIPTION
**NOT READY FOR REVIEW**
trying to understand why in some cases the assertion error is not printed. the current change doesn't fix this.

-----

~This PR exposes the last caught error that occurs when the `chai-retry-plugin` times out before the completion of all retries.~