### PR TITLE
feat(debouncer): added cb setter

### DIFF
--- a/packages/patterns/src/debouncer.ts
+++ b/packages/patterns/src/debouncer.ts
@@ -95,4 +95,8 @@ export class Debouncer<T extends (...args: any[]) => any> {
             clearTimeout(this.maxTimeout);
         }
     }
+
+    setCb(cb: T): void {
+        this.cb = cb;
+    }
 }

--- a/packages/patterns/src/test/debounce.unit.ts
+++ b/packages/patterns/src/test/debounce.unit.ts
@@ -70,4 +70,14 @@ describe('Debounce', () => {
         clock.tick(1);
         expect(callback).to.have.been.calledOnceWith(5);
     });
+    it('can replace cb on a started timer', () => {
+        const callback2 = spy();
+        const throttle = new Debouncer(callback, 4, 10);
+        promises.push(throttle.trigger(1));
+        throttle.setCb(callback2);
+        promises.push(throttle.trigger(2));
+        clock.tick(4);
+        expect(callback).to.have.callCount(0);
+        expect(callback2).to.have.been.calledOnceWith(2);
+    });
 });


### PR DESCRIPTION
This PR adds possibility to set a new callback into a debouncer instance, while keeping the existing timers running.
This is helpful when the callback is context-related and was changed after an action was triggered.